### PR TITLE
Switch input definitions to YAML

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,11 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Python: Run Webserver",
+			"name": "Python: Run Debug Webserver",
 			"type": "python",
 			"request": "launch",
-			"module": "api"
+			"module": "uvicorn",
+			"args": ["api.main:app", "--reload"]
 		}
 	]
 }

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased][unrld]
 ### Changed
 - Switched to [FastAPI](https://fastapi.tiangolo.com/) using [Uvicorn](https://www.uvicorn.org/).
+- Definitions file input now YAML instead of JSON (both should be fine).
 
 ## [0.1.1] (pre-release) - 2022-03-24
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -1,4 +1,4 @@
-import json
+import json, yaml
 from os.path import exists
 from pathlib import Path
 
@@ -30,6 +30,10 @@ class Config(object):
 	def load_json(self, jsonfile:str) -> None:
 		self.content = json.loads( jsonfile )
 		self.loaded  = True
+
+	def load_yml(self, ymlfile:str) -> None:
+		self.content = yaml.load( ymlfile, Loader=yaml.CLoader )
+		self.loaded = True
 
 	def has_config(self) -> bool:
 		"""Whether the class has a configuration loaded into memory.

--- a/api/inspection/inspection.py
+++ b/api/inspection/inspection.py
@@ -120,15 +120,17 @@ class Inspection(object):
 
 		checkpoints = self.codes.get()['cms']
 		for cms in checkpoints:
-			for check in checkpoints[cms]['headers']:
-				key,value = check.split(':', 1)
-				if key in self.headers:
-					if self.headers[key] == value.strip():
+			if checkpoints[cms]['headers'] is not None:
+				for check in checkpoints[cms]['headers']:
+					key,value = check.split(':', 1)
+					if key in self.headers:
+						if self.headers[key] == value.strip():
+							self.reply.add_match(check)
+			if checkpoints[cms]['body'] is not None:
+				for check in checkpoints[cms]['body']:
+					hits = self.parsed.xpath(check)
+					if len(hits) > 0:
 						self.reply.add_match(check)
-			for check in checkpoints[cms]['body']:
-				hits = self.parsed.xpath(check)
-				if len(hits) > 0:
-					self.reply.add_match(check)
 
 			if self.reply.match_count > 0:
 				self.reply.match_total = len(checkpoints[cms]['body']) + len(checkpoints[cms]['headers'])

--- a/api/inspection/inspection.py
+++ b/api/inspection/inspection.py
@@ -120,20 +120,23 @@ class Inspection(object):
 
 		checkpoints = self.codes.get()['cms']
 		for cms in checkpoints:
-			if checkpoints[cms]['headers'] is not None:
+			if 'headers' in checkpoints[cms]:
 				for check in checkpoints[cms]['headers']:
 					key,value = check.split(':', 1)
 					if key in self.headers:
 						if self.headers[key] == value.strip():
 							self.reply.add_match(check)
-			if checkpoints[cms]['body'] is not None:
+			if 'body' in checkpoints[cms]:
 				for check in checkpoints[cms]['body']:
 					hits = self.parsed.xpath(check)
 					if len(hits) > 0:
 						self.reply.add_match(check)
 
 			if self.reply.match_count > 0:
-				self.reply.match_total = len(checkpoints[cms]['body']) + len(checkpoints[cms]['headers'])
+				self.reply.match_total = (
+					len(checkpoints[cms]['body']) if 'body' in checkpoints[cms] else 0 + \
+					len(checkpoints[cms]['headers']) if 'headers' in checkpoints[cms] else 0
+				)
 				self.reply.technology = self.nicename(cms)
 				return
 

--- a/api/main.py
+++ b/api/main.py
@@ -6,7 +6,7 @@ from api import router
 from api.cache import Cache
 from api.config import Config
 
-def_url  = 'https://gist.githubusercontent.com/soup-bowl/ca302eb775278a581cd4e7e2ea4122a1/raw/definition.json'
+def_url  = 'https://gist.githubusercontent.com/soup-bowl/ca302eb775278a581cd4e7e2ea4122a1/raw/definitions.yml'
 def_file = urllib3.PoolManager().request('GET', def_url)
 
 config = Config()
@@ -14,7 +14,7 @@ cache  = Cache()
 
 if def_file.status == 200:
     print("Loaded latest definition file from GitHub.")
-    config.load_json( def_file.data.decode('utf-8') )
+    config.load_yml( def_file.data.decode('utf-8') )
 else:
     print("Unable to download definitions file.")
     exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 lxml==4.8.0
+PyYAML==6.0
 urllib3==1.26.8
 fastapi==0.75.0
 uvicorn==0.17.6


### PR DESCRIPTION
_Glad I'm solo on this project, as this would strike some division._

Since the definitions file is a manually edited construct, I've made the decision to switch it to YAML. My DevOps background means I've been using YAML in Compose and after my initial hang-ups, I see the strength of it for JSON files that are manually edited.

This also fixes the reliance on each definition having a header and body definition for checks. It can now cope with one not existing without crashing.

This PR [adds the pyyaml dependency](https://pypi.org/project/PyYAML/), and changes the definition source to the [.yaml variant in the Gist](https://gist.github.com/soup-bowl/ca302eb775278a581cd4e7e2ea4122a1#file-definitions-yml). Once released, the JSON file will be removed (this project is still in pre-release).